### PR TITLE
Fixed bug where threshold TH is wrongly scaled by GX

### DIFF
--- a/snpm_ui.m
+++ b/snpm_ui.m
@@ -495,7 +495,7 @@ else
 end
 
 %-Compute Grey matter threshold for each image
-if isempty(GX)
+if isempty(GX) | iGMsca==1
     TH    = repmat(THRESH,nScan,1);
 elseif (iTHRESH==3)
     % Absolute threshold


### PR DESCRIPTION
A user specified the (rarely used) ANCOVA normalisation, based on
computed global means.  He _did_ _not_ specify proportional scaling or
global scaling of any sort.  However, on line 504 of snpm_ui, TH was
then scaled by GX… an innocuous error since TH is -Inf, _except_ one of
the globals happened to be _negative_, changing the TH to +Inf!

Hopefully this now fixes it... do you see the problem?  Do you agree with the fix.
