### PR TITLE
Fix for sporadic "Bad PiCond" error.

### DIFF
--- a/snpm_pi_TwoSampT.m
+++ b/snpm_pi_TwoSampT.m
@@ -265,7 +265,7 @@ elseif length(perm)==0 & (nScan<=12) & bAproxTst
     % so can we can just replace first perm.
     PiCond(1,:) = iCond;
     perm = 1;
-else    
+elseif job.nPerm<=nPermMC
     error('SnPM:InvalidPiCond', ['Bad PiCond (' num2str(perm) ')'])
 end    
 


### PR DESCRIPTION
With two-sample T-test, a Monte Carlo permutation test is used when there are more than a certain number of permutations (`nPermMC = 2000`). This then prevents the (computation- and memory-intensive) checking for duplicate permutations.  However, a later check for duplicate original-labellings was still active even when nPerm>nPermMC, causing a sporadic "Bad PiCond" error.

This one-line fix prevents the check for duplicates when a Monte Carlo permutation test is used.