### PR TITLE
Tests: If ground truth is not available for a given Matlab version use latest available (2016b)

### DIFF
--- a/test/common/generic_test_snpm.m
+++ b/test/common/generic_test_snpm.m
@@ -25,6 +25,7 @@ classdef generic_test_snpm < matlab.unittest.TestCase
         numBetas;
         inter_map;
         batch_map;
+        stat_tolerance;
         tolerance;
         mapName;
         SnPMrefVersion;
@@ -79,6 +80,8 @@ classdef generic_test_snpm < matlab.unittest.TestCase
             
             testCase.checks = true;
             testCase.warningId = '';
+            
+            testCase.stat_tolerance = 10^-10;
         end
         
         function update_basis_matlabbatch(testCase)
@@ -147,7 +150,7 @@ classdef generic_test_snpm < matlab.unittest.TestCase
             % Compare t-maps
             testCase.inter_map = inter_tmap;
             testCase.batch_map = batch_tmap;
-            testCase.tolerance = 10^-10;
+            testCase.tolerance = testCase.stat_tolerance;
             testCase.mapName = 'tmap';
             testCase.compare_batch_with_inter();
             
@@ -195,7 +198,7 @@ classdef generic_test_snpm < matlab.unittest.TestCase
             % Compare filtered maps
             testCase.inter_map = inter_filtmap;
             testCase.batch_map = batch_filtmap;
-            testCase.tolerance = 10^-10;
+            testCase.tolerance = testCase.stat_tolerance;
             testCase.mapName = 'filtered map';
             refVersion = regexp(testCase.SnPMrefVersion, '^SnPM(?<num>\d+)\.?(?<subnum>\d?\d?)', 'names');
             zeroingNaNs = false;
@@ -220,11 +223,12 @@ classdef generic_test_snpm < matlab.unittest.TestCase
                 ['GT_' strrep(testCase.SnPMrefVersion, '.', '') '_' version('-release')], testCase.testName);
             
             if ~exist(testCase.interResDir, 'dir')
-                warning(['Ground truth data for ' version('-release') ' is not available yet' ... 
+                warning('test:noGroundTruth', ['Ground truth data for ' version('-release') ' is not available yet' ... 
                     ', please consider sending an update at https://github.com/SnPM-toolbox/SnPM_test_data.' ...
-                    ' Data generated with 2014b will be used instead for testing.']);
+                    ' Data generated with 2014b will be used instead for testing and tolerance increased.']);
                 testCase.interResDir = fullfile(spm_str_manip(testCase.batchResDir,'hh'), ...
                     ['GT_' strrep(testCase.SnPMrefVersion, '.', '') '_2014b'], testCase.testName);
+                testCase.stat_tolerance = 10^(-6);
             end
             
             if ~exist(testCase.batchResDir, 'dir')

--- a/test/common/generic_test_snpm.m
+++ b/test/common/generic_test_snpm.m
@@ -227,7 +227,7 @@ classdef generic_test_snpm < matlab.unittest.TestCase
                     ', please consider sending an update at https://github.com/SnPM-toolbox/SnPM_test_data.' ...
                     ' Data generated with 2014b will be used instead for testing and tolerance increased.']);
                 testCase.interResDir = fullfile(spm_str_manip(testCase.batchResDir,'hh'), ...
-                    ['GT_' strrep(testCase.SnPMrefVersion, '.', '') '_2014b'], testCase.testName);
+                    ['GT_' strrep(testCase.SnPMrefVersion, '.', '') '_2016b'], testCase.testName);
                 testCase.stat_tolerance = 10^(-6);
             end
             

--- a/test/common/generic_test_snpm.m
+++ b/test/common/generic_test_snpm.m
@@ -219,6 +219,14 @@ classdef generic_test_snpm < matlab.unittest.TestCase
             testCase.interResDir = fullfile(spm_str_manip(testCase.batchResDir,'hh'), ...
                 ['GT_' strrep(testCase.SnPMrefVersion, '.', '') '_' version('-release')], testCase.testName);
             
+            if ~exist(testCase.interResDir, 'dir')
+                warning(['Ground truth data for ' version('-release') ' is not available yet' ... 
+                    ', please consider sending an update at https://github.com/SnPM-toolbox/SnPM_test_data.' ...
+                    ' Data generated with 2014b will be used instead for testing.']);
+                testCase.interResDir = fullfile(spm_str_manip(testCase.batchResDir,'hh'), ...
+                    ['GT_' strrep(testCase.SnPMrefVersion, '.', '') '_2014b'], testCase.testName);
+            end
+            
             if ~exist(testCase.batchResDir, 'dir')
                 mkdir(testCase.batchResDir);
             else


### PR DESCRIPTION
This PR updates the test code so that if ground truth test data is not available for a given Matlab version, the tests are run against the ground truth corresponding to Matlab 2014b (current latest version covered by https://github.com/SnPM-toolbox/SnPM_test_data).

In that case tolerance to compare statistic maps is increased from `10^-10` to `10^-6`. On my machine, this allows for all the tests to pass except:
```
Failure Summary:

     Name                                         Failed  Incomplete  Reason(s)
    ==========================================================================================
     test_ANOVAbetween/test_ANOVAbetween_1          X                 Failed by verification.
    ------------------------------------------------------------------------------------------
     test_ANOVAbetween/test_ANOVAbetween_allzero    X                 Failed by verification.
    ------------------------------------------------------------------------------------------
     test_ANOVAbetween/test_ANOVAbetween_var        X                 Failed by verification.
    

result = 

  1×70 TestResult array with properties:

    Name
    Passed
    Failed
    Incomplete
    Duration
    Details

Totals:
   67 Passed, 3 Failed, 0 Incomplete.
   262.2152 seconds testing time.
```

Looking more closely at the first failure. Part of the error is as follows:
```
================================================================================
Verification failed in test_ANOVAbetween/test_ANOVAbetween_1.

    ----------------
    Test Diagnostic:
    ----------------
    /Users/cmaumet/Desktop/SnPM_test_data/results/batch/ANOVAbetween_1/lP+.hdr

    ---------------------
    Framework Diagnostic:
    ---------------------
    verifyEqual failed.
    --> The values are not equal using "isequaln".
    --> The error was not within absolute tolerance.
    --> Failure table (First 50 out of 455 failed indices):
                Index    Subscripts          Actual                Expected                 Error               RelativeError       AbsoluteTolerance
                _____    __________    ___________________    ___________________    ____________________    ___________________    _________________
            
                  1      (1,1,1)         0.491844511540369      0.522878745280338     -0.0310342337399688    -0.0593526396322154    1e-10            
                  2      (2,1,1)         0.190814515876388      0.198367653766833    -0.00755313789044593     -0.038076459276592    1e-10            
                  4      (4,1,1)         0.183390497797181      0.190814515876388     -0.0074240180792069    -0.0389069879988391    1e-10            
                  6      (6,1,1)         0.397940008672038       0.42276359239707     -0.0248235837250321    -0.0587174112706404    1e-10            
                 12      (2,2,1)           0.9128498242811      0.954242509439325      -0.041392685158225    -0.0433775321773767    1e-10            
                 18      (8,2,1)         0.352182518111363      0.363177902412826     -0.0109953843014631    -0.0302754771928955    1e-10            
                 19      (9,2,1)         0.134698573897456      0.141329152796469    -0.00663057889901306    -0.0469158610790081    1e-10            
                 20      (10,2,1)       0.0791812460476248      0.067751784266843      0.0114294617807818      0.168696100102197    1e-10            
                 23      (3,3,1)           0.9128498242811                      1     -0.0871501757189002    -0.0871501757189002    1e-10            
                 24      (4,3,1)         0.141329152796469      0.148062535455438    -0.00673338265896839    -0.0454766132314068    1e-10            
                 27      (7,3,1)        0.0404286570556082     0.0351644170632509     0.00526423999235725       0.14970360472316    1e-10            
```
I think we should not increase the tolerance any further to account for those errors. 

This update could still be useful when working with closer Matlab version. I will create test data for Matlab 2016b now.