### PR TITLE
Updated cluster forming threshold default

### DIFF
--- a/snpm_defaults.m
+++ b/snpm_defaults.m
@@ -19,7 +19,8 @@ global SnPMdefs
 %------------------------------------------------------------------------
 SnPMdefs.STalpha = 0.01; % T values above this sig are save for ST analysis
 SnPMdefs.STprop  = 0.10; % 100*(1-STprop)%ile of observed Psuedo T values saved
-SnPMdefs.ST_U    = 2.03; % Default cluster-forming threshold set pre-analysis
+                         % Default cluster-forming threshold set pre-analysis
+SnPMdefs.ST_U    = spm_invNcdf(1-0.001);
 
 % Work in "high memory" mode?
 %------------------------------------------------------------------------


### PR DESCRIPTION
Previous threshold, 2.03, is a typo, intended to be 2.3

However, based on recommendations from Woo et al., I am now changing this default to the exact threshold based on 0.001.
