### PR TITLE
Updated cluster forming threshold default

### DIFF
--- a/snpm_defaults.m
+++ b/snpm_defaults.m
@@ -19,7 +19,8 @@ global SnPMdefs
 %------------------------------------------------------------------------
 SnPMdefs.STalpha = 0.01; % T values above this sig are save for ST analysis
 SnPMdefs.STprop  = 0.10; % 100*(1-STprop)%ile of observed Psuedo T values saved
-SnPMdefs.ST_U    = 2.03; % Default cluster-forming threshold set pre-analysis
+                         % Default cluster-forming threshold set pre-analysis
+SnPMdefs.ST_U    = spm_invNcdf(1-0.001);
 
 % Work in "high memory" mode?
 %------------------------------------------------------------------------


### PR DESCRIPTION
Previous "2.03" threshold was a typo, for what should have been 2.3.
Instead of  just correcting the typo, or changing to more precise `spm_invNcdf(1-0.01)`, I am following the advice of [Woo et al., 2014](https://www.ncbi.nlm.nih.gov/pubmed/24412399) to raise to alpha level 0.001. (Based on the concerns of difficult interpretability of large clusters generated by generous cluster forming thresholds).