### PR TITLE
Adding Zenodo's badge to the README (with doi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## SnPM: Statistical nonParametric Mapping
 
+[![DOI](https://zenodo.org/badge/12644851.svg)](https://zenodo.org/badge/latestdoi/12644851)
+
 The Statistical non-Parametric Mapping (SnPM) toolbox provides an extensible framework for voxel level non-parametric permutation/randomisation tests of functional Neuroimaging experiments with independent observations. 
 
 The SnPM toolbox provides an alternative to the Statistics section of [SPM](http://www.fil.ion.ucl.ac.uk/spm/). SnPM uses the General Linear Model to construct pseudo t-statistic images, which are then assessed for significance using a standard non-parametric multiple comparisons procedure based on randomisation/permutation testing. It is most suitable for single subject PET/SPECT analyses, or designs with low degrees of freedom available for variance estimation. In these situations the freedom to use weighted locally pooled variance estimates, or variance smoothing, makes the non-parametric approach considerably more powerful than conventional parametric approaches, as are implemented in SPM. Further, the non-parametric approach is always valid, given only minimal assumptions.


### PR DESCRIPTION
Following integration with Zenodo (as discussed in https://github.com/SnPM-toolbox/SnPM-devel/issues/58), this PR updates the README to add the badge with the corresponding DOI (generated by Zenodo).

The DOI is not functional yet but will hopefully be soon. 