### PR TITLE
Create new nSubj limit for Paired T test; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ The Statistical non-Parametric Mapping (SnPM) toolbox provides an extensible fra
 
 The SnPM toolbox provides an alternative to the Statistics section of [SPM](http://www.fil.ion.ucl.ac.uk/spm/). SnPM uses the General Linear Model to construct pseudo t-statistic images, which are then assessed for significance using a standard non-parametric multiple comparisons procedure based on randomisation/permutation testing. It is most suitable for single subject PET/SPECT analyses, or designs with low degrees of freedom available for variance estimation. In these situations the freedom to use weighted locally pooled variance estimates, or variance smoothing, makes the non-parametric approach considerably more powerful than conventional parametric approaches, as are implemented in SPM. Further, the non-parametric approach is always valid, given only minimal assumptions.
 
-**More information at: www.warwick.ac.uk/snpm**
+**More information at: http://www.nisox.org/Software/SnPM**
 
- - [Getting started](http://www.warwick.ac.uk/snpm/man)
- - [fMRI example](http://www.warwick.ac.uk/snpm/man/exnew)
- - [PET example](http://www.warwick.ac.uk/snpm/man/ex)
- - [Download](http://www.warwick.ac.uk/snpm/snpmreg)
+ - [Getting started](http://www.nisox.org/Software/SnPM13/man)
+ - [fMRI example](http://www.nisox.org/Software/SnPM13/man/exnew)
+ - [PET example](http://www.nisox.org/Software/SnPM13/man/ex)
+ - [Download](http://www.nisox.org/Software/SnPM13/snpmreg)
 
 
 ### Non-regression testing
@@ -46,7 +46,7 @@ run(test_oneSample, 'test_onesample_1')
 ### SnPM13: Bugs & Fixes
 
 This section describes the bugs that have been reported, along with the appropriate fixes. 
-Updated versions of appropriate SnPM functions are available at [snpm13_updates](http://warwick.ac.uk/snpm/distribution/snpm13_updates)
+Updated versions of appropriate SnPM functions are available at [snpm13_updates](http://www.nisox.org/Software/SnPM13/snpm13_updates)
 
 #####  SnPM 13.1.05
  * fix: two-sample t-test with nscans>12 was errored due to call to undefined variable `nPerm` (bug introduced in previous release: 13.1.4) (`snpm_pi_TwoSampT`)

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@ SnPM13: Bugs & Fixes
 
 This file describes the bugs that have been reported, along with the appropriate fixes. 
 Updated versions of appropriate SnPM functions are available from in the snpm13_updates: 
-http://warwick.ac.uk/snpm/distribution/snpm13_updates
+http://www.nisox.org/Software/SnPM13/snpm13_updates
 
 --- SnPM 13.1.07 ---
  * fix: Add GPL licence. 

--- a/snpm_defaults.m
+++ b/snpm_defaults.m
@@ -60,3 +60,8 @@ SnPMdefs.shuffle_seed = true;
 %------------------------------------------------------------------------
 SnPMdefs.Results_distmin = 8;   % Minimum distance between peaks
 SnPMdefs.Results_nbmax   = 3;   % Maximum number secondary peaks
+
+% In Paired T test plugin, maximum number of subjects for which exhustive
+% computation of permutations can be conducted.
+%------------------------------------------------------------------------
+SnPMdefs.pi_PairT_MaxExh = 25; 

--- a/snpm_pi_PairT.m
+++ b/snpm_pi_PairT.m
@@ -118,6 +118,8 @@ if snpm_get_defaults('shuffle_seed')
         rand('seed',sum(100*clock));
     end
 end
+MaxExh_nSubj = snpm_get_defaults('pi_PairT_MaxExh');
+
 
 				% PlugIn variables to save in cfg file
 
@@ -236,7 +238,7 @@ end
 %=======================================================================
 %-All possible labelings correspond to the binary representation of
 % numbers {1...2^nSubj}.
-if nSubj<=35
+if nSubj<=MaxExh_nSubj
   if (bAproxTst)
     tmp = randperm(2^nSubj)-1;
     tmp = tmp(1:nPiSubj)';


### PR DESCRIPTION
The Paired T test plugin has two modes to find permutations, one computationally efficient but memory hungry, the other memory efficient.  The threshold for switching between these methods was hard coded to 35.  This PR adds a new default, `SnPMdefs.pi_PairT_MaxExh` to control this setting and lowers the default to 25.  Thanks to Remko van Lutterveld to reporting this problem.

The README.md and README.txt had references to the Wariwick website.  These have been updated to reference the NISOx website.