### PR TITLE
Forward compatibility for batch lazy-loading in SPM devel

### DIFF
--- a/config/snpm_bch_ui_PairT.m
+++ b/config/snpm_bch_ui_PairT.m
@@ -35,6 +35,9 @@ DesHelp = {'',...
 % Reuse flexible factorial component of SPM to get the design files and
 % associated conditions
 factorial_design = spm_cfg_factorial_design();
+if isa(factorial_design.val,'function_handle')
+    factorial_design.val = feval(factorial_design.val);
+end
 sub_files = factorial_design.val{2}.values{end}.val{2}.val{1};
 
 % We expect exactly two files per subject

--- a/config/snpm_bch_ui_TwoSampPairT.m
+++ b/config/snpm_bch_ui_TwoSampPairT.m
@@ -28,6 +28,9 @@ DesHelp = {'',...
 % Reuse flexible factorial component of SPM to get the design files and
 % associated conditions
 factorial_design = spm_cfg_factorial_design();
+if isa(factorial_design.val,'function_handle')
+    factorial_design.val = feval(factorial_design.val);
+end
 sub_files = factorial_design.val{2}.values{end}.val{2}.val{1};
 
 % We expect exactly two files per subject


### PR DESCRIPTION
#### What does this PR do?

In a future version of SPM, batch modules can be evaluated on request instead of at start time (lazy-loading). As a consequence, this means that the `.val` field of a module can contain a function handle which, when executed, will return the parameters of a module, instead of directly containing the parameters themselves (as in SPM12).

The proposed change guarantees that SnPM will work with current and future versions of SPM for that matter.

#### Link to relevant issues

#### PR submission checklist
 - [X] Run the tests (cf. [instructions](https://github.com/SnPM-toolbox/SnPM-devel#non-regression-testing))
 - [ ] Copy/paste the test report in a comment below
 - [ ] All tests in the test suite pass

Tests fail because they rely on nansum() from the Statistics toolbox, which is not installed on my system.