### PR TITLE
Replace deprecated str2mat by char

### DIFF
--- a/snpm_pi_ANOVAbtwnS.m
+++ b/snpm_pi_ANOVAbtwnS.m
@@ -195,10 +195,10 @@ for i = 1:g
         end
         G = [G, d];
         dnames = job.cov(i).cname;
-        Gcnames = str2mat(Gcnames,dnames);
+        Gcnames = char(Gcnames,dnames);
     end
 end
-%-Strip off blank line from str2mat concatenations
+%-Strip off blank line from char concatenations
 if size(Gc,2), Gcnames(1,:)=[]; end
 %-Since no FxC interactions these are the same
 Gnames = Gcnames;

--- a/snpm_pi_ANOVAwithinS.m
+++ b/snpm_pi_ANOVAwithinS.m
@@ -139,7 +139,7 @@ iRepl = [];
 iSubj = [];
 for subj=1:nSubj
     %tmp = ['Subject ',int2str(subj),': Select scans in time order'];
-    P = str2mat(P, str2mat(job.fsubject(subj).scans)); %str2mat(P,spm_select(nRepl,'image',tmp));
+    P = char(P, char(job.fsubject(subj).scans)); %char(P,spm_select(nRepl,'image',tmp));
     iRepl = [iRepl, 1:nRepl];
     iSubj = [iSubj, subj*ones(1,nRepl)];
 end
@@ -167,10 +167,10 @@ if numel(job.cov) > 0 %isfield(job.covariate,'cov_Val')
             d  = d - ones(q,1)*mean(d); str='';
             G = [G, d];
             dnames = job.cov(i).cname;
-            Gcnames = str2mat(Gcnames,dnames);
+            Gcnames = char(Gcnames,dnames);
         end
     end
-    %-Strip off blank line from str2mat concatenations
+    %-Strip off blank line from char concatenations
     if size(Gc,2)
         Gcnames(1,:)=[];
     end

--- a/snpm_pi_Corr.m
+++ b/snpm_pi_Corr.m
@@ -136,12 +136,12 @@ if numel(job.cov) > 0 %isfield(job.covariate,'cov_Val')
             dnames = job.cov(i).cname;
     %         dnames = [str,'ConfCov#',int2str(nGcs+1)];
     %         for j = nGcs+1:nGcs+size(d,1)
-    %             dnames = str2mat(dnames,['ConfCov#',int2str(j)]); 
+    %             dnames = char(dnames,['ConfCov#',int2str(j)]); 
     %         end
-            Gcnames = str2mat(Gcnames,dnames);
+            Gcnames = char(Gcnames,dnames);
         end 
     end
-    %-Strip off blank line from str2mat concatenations
+    %-Strip off blank line from char concatenations
     if size(Gc,2)
         Gcnames(1,:)=[]; 
     end

--- a/snpm_pi_Corr1S.m
+++ b/snpm_pi_Corr1S.m
@@ -132,12 +132,12 @@ if numel(job.cov) > 0 %isfield(job.covariate,'cov_Val')
             dnames = job.cov(i).cname;
     %         dnames = [str,'ConfCov#',int2str(nGcs+1)];
     %         for j = nGcs+1:nGcs+size(d,1)
-    %             dnames = str2mat(dnames,['ConfCov#',int2str(j)]); 
+    %             dnames = char(dnames,['ConfCov#',int2str(j)]); 
     %         end
-            Gcnames = str2mat(Gcnames,dnames);
+            Gcnames = char(Gcnames,dnames);
         end 
     end
-    %-Strip off blank line from str2mat concatenations
+    %-Strip off blank line from char concatenations
     if size(Gc,2)
         Gcnames(1,:)=[]; 
     end
@@ -151,7 +151,7 @@ Gnames = Gcnames;
 tmp      = nScan./[nScan:-1:1];
 Xblk     = tmp( floor(tmp)==ceil(tmp) & tmp>1 );
 tmp      = int2str(Xblk(1));
-for i=2:length(Xblk), tmp=str2mat(tmp,int2str(Xblk(i))); end
+for i=2:length(Xblk), tmp=char(tmp,int2str(Xblk(i))); end
 if length(Xblk)>1
   Xblk     = job.xblock;%spm_input('Size of exchangability block','+0','b',tmp,Xblk);
 end

--- a/snpm_pi_OneSampT.m
+++ b/snpm_pi_OneSampT.m
@@ -135,12 +135,12 @@ if numel(job.cov) > 0 %isfield(job.covariate,'cov_Val')
             dnames = job.cov(i).cname;
     %         dnames = [str,'ConfCov#',int2str(nGcs+1)];
     %         for j = nGcs+1:nGcs+size(d,1)
-    %             dnames = str2mat(dnames,['ConfCov#',int2str(j)]); 
+    %             dnames = char(dnames,['ConfCov#',int2str(j)]); 
     %         end
-            Gcnames = str2mat(Gcnames,dnames);
+            Gcnames = char(Gcnames,dnames);
         end 
     end
-    %-Strip off blank line from str2mat concatenations
+    %-Strip off blank line from char concatenations
     if size(Gc,2)
         Gcnames(1,:)=[]; 
     end

--- a/snpm_pi_PairT.m
+++ b/snpm_pi_PairT.m
@@ -142,7 +142,7 @@ iSubjC= [];
 iRepl = [];
 for subj=1:nSubj
     tmp = ['Subject ',int2str(subj),': Select scans in time order'];
-    P = str2mat(P, str2mat(job.fsubject(subj).scans)); %str2mat(P,spm_select(nCond*nRepl,'image',tmp));
+    P = char(P, char(job.fsubject(subj).scans)); %char(P,spm_select(nCond*nRepl,'image',tmp));
     Cond=[];
     while(isempty(Cond))
 %         tmp=['Enter conditions index: (A/B) [',int2str(nCond*nRepl),']'];
@@ -308,7 +308,7 @@ sHCform    = 'spm_DesMtx(PiCond(perm,:),''-'',''Cond'')';
 [H] = spm_DesMtx(iCond,'-','Cond');
 Hnames=[];
 for i=1:nCond
-    Hnames=str2mat(Hnames,['Cond_',sCond(i)]); end
+    Hnames=char(Hnames,['Cond_',sCond(i)]); end
 Hnames(1,:) = [];    
 %-Contrast of condition effects
 % (spm_DesMtx puts condition effects in index order)

--- a/snpm_pi_PairTrand.m
+++ b/snpm_pi_PairTrand.m
@@ -126,7 +126,7 @@ iSubjC= [];
 iRepl = [];
 for subj=1:nSubj
     tmp = ['Subject ',int2str(subj),': Select scans in time order'];
-    P = str2mat(P,spm_select(nCond*nRepl,'image',tmp));
+    P = char(P,spm_select(nCond*nRepl,'image',tmp));
     Cond=[];
     while(isempty(Cond))
 	tmp=['Enter conditions index: (A/B) [',int2str(nCond*nRepl),']'];
@@ -266,7 +266,7 @@ sHCform    = 'spm_DesMtx(PiCond(perm,:),''-'',''Cond'')';
 [H] = spm_DesMtx(iCond,'-','Cond');
 Hnames=[];
 for i=1:nCond
-    Hnames=str2mat(Hnames,['Cond_',sCond(i)]); end
+    Hnames=char(Hnames,['Cond_',sCond(i)]); end
 Hnames(1,:) = [];    
 %-Contrast of condition effects
 % (spm_DesMtx puts condition effects in index order)

--- a/snpm_pi_TwoSampPairT.m
+++ b/snpm_pi_TwoSampPairT.m
@@ -147,7 +147,7 @@ for stud=1:nStud
     tmpCond = job.(['scans' num2str(stud)]).fsubject(subj).scindex;%
     tmpCond = tmpCond-min(tmpCond);
     Cond = -(tmpCond/max([1,tmpCond])*2-1);
-	P = str2mat(P,str2mat(tP));
+	P = char(P,char(tP));
 	% update indicators	
 	iCond = [iCond, Cond];
 	iSubj = [iSubj, subj*ones(1,nCond)];
@@ -183,13 +183,13 @@ for i = 1:g
     G = [G, d];
     dnames = job.cov(i).cname; %[str,'ConfCov#',int2str(nGcs+1)];
 %     for j = nGcs+1:nGcs+size(d,1)
-%       dnames = str2mat(dnames,job.cov(j).cname);%str2mat(dnames,['ConfCov#',int2str(i)]); 
+%       dnames = char(dnames,job.cov(j).cname);%char(dnames,['ConfCov#',int2str(i)]); 
 %     end
-    Gcnames = str2mat(Gcnames,dnames);
+    Gcnames = char(Gcnames,dnames);
   end
 %end
 end
-%-Strip off blank line from str2mat concatenations
+%-Strip off blank line from char concatenations
 if size(Gc,2), Gcnames(1,:)=[]; end
 %-Since no FxC interactions these are the same
 Gnames = Gcnames;

--- a/snpm_pi_TwoSampT.m
+++ b/snpm_pi_TwoSampT.m
@@ -163,10 +163,10 @@ for i = 1:g
         end
         G = [G, d];
         dnames = job.cov(i).cname;
-        Gcnames = str2mat(Gcnames,dnames);
+        Gcnames = char(Gcnames,dnames);
     end
 end
-%-Strip off blank line from str2mat concatenations
+%-Strip off blank line from char concatenations
 if size(Gc,2), Gcnames(1,:)=[]; end
 %-Since no FxC interactions these are the same
 Gnames = Gcnames;

--- a/snpm_pi_TwoSampTss.m
+++ b/snpm_pi_TwoSampTss.m
@@ -102,7 +102,7 @@ end
 tmp      = nRepl./[nRepl:-1:1];
 Xblk     = nCond * tmp(floor(tmp)==ceil(tmp));
 tmp      = int2str(Xblk(1));
-for i=2:length(Xblk), tmp=str2mat(tmp,int2str(Xblk(i))); end
+for i=2:length(Xblk), tmp=char(tmp,int2str(Xblk(i))); end
 Xblk     = job.TwosampTss_Block; %spm_input('Size of exchangability block','+1','b',tmp,Xblk);
 nXblk    = nCond*nRepl/Xblk;
 iXblk    = meshgrid(1:nXblk,1:Xblk); iXblk = iXblk(:)';

--- a/snpm_ui.m
+++ b/snpm_ui.m
@@ -193,7 +193,7 @@ end
   
 %-Definitions & Design parameters
 %=======================================================================
-sDesigns=str2mat(...
+sDesigns=char(...
 	'SingleSub: Two Sample T test; 2 conditions',...
 	'SingleSub: Simple Regression; 1 covariate of interest',...
 	'MultiSub: One Sample T test on differences; 1 condition',...
@@ -207,7 +207,7 @@ sDesigns=str2mat(...
         'User Specified PlugIn',...
 	'keyboard');
 
-sDesFile=str2mat(...
+sDesFile=char(...
         'snpm_pi_TwoSampTss', ...
 	'snpm_pi_Corr1S', ...
 	'snpm_pi_OneSampT', ...     
@@ -228,7 +228,7 @@ sDesFile=str2mat(...
 %%%
 
 %-Global normalization                                    (GloNorm)
-sGloNorm=str2mat(... 
+sGloNorm=char(... 
 	'<no global normalisation>',...				%-1
 	'proportional scaling',...				%-2
 	'AnCova',...						%-3
@@ -236,13 +236,13 @@ sGloNorm=str2mat(...
 	'AnCova {study-specific}');				%-5
 
 %-Global calculation options                               (GXcalc)
-sGXcalc  = str2mat(...
+sGXcalc  = char(...
     'omit',...							%-1
     'user specified',...					%-2
     'mean voxel value (within per image fullmean/8 mask)');	%-3
 
 %-Grand mean scaling options                                (GMsca)
-sGMsca = str2mat(...
+sGMsca = char(...
     '<no grand Mean scaling>',...				%-1
     'scaling of overall grand mean');				%-2
 
@@ -517,7 +517,7 @@ end
 %=======================================================================
 Gc    = [Gc,GX];
 if isempty(Gcnames), Gcnames = 'Global';
-else, Gcnames = str2mat(Gcnames,'Global'); end
+else, Gcnames = char(Gcnames,'Global'); end
 
 if iGloNorm == 1				%-No global adjustment
 %-----------------------------------------------------------------------
@@ -533,21 +533,21 @@ elseif iGloNorm == 3				%-AnCova
 %-----------------------------------------------------------------------
    G = [G,(GX - mean(GX))];
    if isempty(Gnames), Gnames = 'Global'; 
-   else, Gnames = str2mat(Gnames,'Global'); end
+   else, Gnames = char(Gnames,'Global'); end
 
 elseif iGloNorm == 4				%-AnCova by subject
 %-----------------------------------------------------------------------
     [GL,GLnames] = spm_DesMtx([iSUBJ',GX-mean(GX)],'FxC',['SUBJ  ';'Global']);
     G = [G,GL];
     if isempty(Gnames), Gnames = GLnames;
-    else, Gnames = str2mat(Gnames,GLnames); end
+    else, Gnames = char(Gnames,GLnames); end
 
 elseif iGloNorm == 5				%-AnCova by study
 %-----------------------------------------------------------------------
     [GL,GLnames] = spm_DesMtx([iStud',GX-mean(GX)],'FxC',['Stud  ';'Global']);
     G = [G,GL];
     if isempty(Gnames), Gnames = GLnames; 
-    else, Gnames = str2mat(Gnames,GLnames); end
+    else, Gnames = char(Gnames,GLnames); end
 else
 %-----------------------------------------------------------------------
     error('SnPM:InvalidiGloNorm', sprintf('%cError: invalid iGloNorm option\n',7))


### PR DESCRIPTION
#### What does this PR do?
Replaces all occurrence of `str2mat` by `char` as per recommendation by Matlab, see https://fr.mathworks.com/help/matlab/ref/str2mat.html

#### PR submission checklist
 - [ ] Run the tests (cf. [instructions](https://github.com/SnPM-toolbox/SnPM-devel#non-regression-testing))
 - [ ] Copy/paste the test report in a comment below
 - [ ] All tests in the test suite pass